### PR TITLE
Add new Loki API URL

### DIFF
--- a/lib/fluent/plugin/out_loki.rb
+++ b/lib/fluent/plugin/out_loki.rb
@@ -115,7 +115,7 @@ class Fluent::Plugin::LokiOutput < Fluent::Plugin::Output
 
   def create_request(tag, time, record)
     url = format_url(tag, time, record)
-    uri = URI.parse(url+"/api/prom/push")
+    uri = URI.parse(url+"/loki/api/v1/push")
     req = Net::HTTP::Post.new(uri.request_uri)
     set_body(req, tag, time, record)
     set_header(req, tag, time, record)


### PR DESCRIPTION
New Loki version has changed API URL. Fixed hardcode URI add to actual API URL. Or you can just remove this option and add a note to docs about it.